### PR TITLE
Update rsf.py

### DIFF
--- a/qiniu/rsf.py
+++ b/qiniu/rsf.py
@@ -36,6 +36,6 @@ class Client(object):
 			ops['prefix'] = prefix
 		url = '%s?%s' % ('/list', urllib.urlencode(ops))
 		ret, err = self.conn.call_with(url, body=None, content_type='application/x-www-form-urlencoded')
-		if not ret.get('marker'):
+		if ret and not ret.get('marker'):
 			err = EOF
 		return ret, err


### PR DESCRIPTION
`if not ret.get('marker'):` 在ret为`None`时会报错。

这种边界问题不太好测试出来呢。:)
