### PR TITLE
encode '/' character when quoting key

### DIFF
--- a/qiniu/rs/rs_token.py
+++ b/qiniu/rs/rs_token.py
@@ -105,4 +105,4 @@ def make_base_url(domain, key):
 	 * return base_url
 	'''
 	key = rpc.encode_unicode(key)
-	return 'http://%s/%s' % (domain, urllib.quote(key))
+	return 'http://%s/%s' % (domain, urllib.quote(key, safe=''))


### PR DESCRIPTION
The default value of `safe` argument is '/'. In such case, '/' character in key will not be encoded.
Although there is no '/' character in my accessKey, I think encoding '/' character is right.
