### PR TITLE
Support Google AppEngine, fix import error

### DIFF
--- a/qiniu/rpc.py
+++ b/qiniu/rpc.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-import httplib_chunk as httplib
+
+import httplib
+
+if not getattr(httplib, "_IMPLEMENTATION", False):   # httplib._IMPLEMENTATION is "gae" on GAE
+    import httplib_chunk as httplib
+
 import json
 import cStringIO
 import conf


### PR DESCRIPTION
GAE httplib implementation uses google.appengine.api.urlfetch
