### PR TITLE
Fix variable name in doc

### DIFF
--- a/docs/gist/demo.py
+++ b/docs/gist/demo.py
@@ -359,7 +359,7 @@ def list_prefix_all():
 # @gist list_all
 
 
-def list_all(bucket, rs=None, prefix=None, limit=None):
+def list_all(bucket_name, rs=None, prefix=None, limit=None):
     if rs is None:
         rs = qiniu.rsf.Client()
     marker = None


### PR DESCRIPTION
"bucket_name"is used in Line 369, which is different from first argument of the method.
BTW, how to generate README.md from README.gist.md? Do I need to install gist gem?
