### PR TITLE
fix 如果没有提前装过requests,则setup出错的bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='qiniu',
-    version=__import__('qiniu').__version__,
+    version='7.0.0',
     description='Qiniu Resource Storage SDK',
     long_description='see:\nhttps://github.com/qiniu/python-sdk\n',
     author='Shanghai Qiniu Information Technologies Co., Ltd.',


### PR DESCRIPTION
查看setup.py不难发现`version=__import__('qiniu').__version__`

查看qiniu/**init**.py 可以看到在这里除了有`__version__`之外还导入了各种东西，其中`from .auth import Auth`刚好依赖与request

这就直接导致这么一个问题： 如果用户没有提前安装过requests则直接安装失败.

解决这个问题大体有几个思路：
1. 去除掉**init**.py里面其他的导入，做一个package的时候，不应该在存在依赖时导入模块，主要写version,author信息，当然现在这么做不确定是否会对其他依赖与这个库的库造成影响；
2. 在setup.py中直接写一个version版本号，虽然违反DRY,不过没有这时候确实是应该违反DRY的时候
