### PR TITLE
A little fix to separate the get request with auth header and without au...

### DIFF
--- a/qiniu/http.py
+++ b/qiniu/http.py
@@ -46,13 +46,23 @@ def _post(url, data, files, auth):
     return __return_wrapper(r)
 
 
-def _get(url, params, auth):
+def _get(url, params):
+    try:
+        r = requests.get(
+            url, params=params,
+            timeout=config.get_default('connection_timeout'), headers=_headers)
+    except Exception as e:
+        return None, ResponseInfo(None, e)
+    return __return_wrapper(r)
+
+
+def _get_with_auth(url, params, auth):
     try:
         r = requests.get(
             url, params=params, auth=RequestsAuth(auth),
             timeout=config.get_default('connection_timeout'), headers=_headers)
     except Exception as e:
-        return None,  ResponseInfo(None, e)
+        return None, ResponseInfo(None, e)
     return __return_wrapper(r)
 
 

--- a/qiniu/services/storage/bucket.py
+++ b/qiniu/services/storage/bucket.py
@@ -101,7 +101,7 @@ class BucketManager(object):
         return http._post_with_auth(url, data, self.auth)
 
     def __get(self, url, params=None):
-        return http._get(url, params, self.auth)
+        return http._get_with_auth(url, params, self.auth)
 
 
 def _build_op(*args):


### PR DESCRIPTION
...th header

@longbai 

Do this fix to support code like this:

``` python

from qiniu import http

url = "http://api.qiniu.com/status/get/prefop"
params = {"id": "54898c247823de40683b32cc"}
retData, respInfo = http._get(url, params)
print(retData)
print(respInfo)
```
