### PR TITLE
添加断点续传功能

### DIFF
--- a/qiniu/services/storage/upload_progress_recorder.py
+++ b/qiniu/services/storage/upload_progress_recorder.py
@@ -4,43 +4,41 @@ import json
 import os
 import tempfile
 
+
 class UploadProgressRecorder(object):
-  """持久化上传记录类
+    """持久化上传记录类
 
-  该类默认保存每个文件的上传记录到文件系统中，用于断点续传
-  上传记录为json格式：
-  {
-      "size": file_size,
-      "offset": upload_offset,
-      "modify_time": file_modify_time,
-      "contexts": contexts
-  }
+    该类默认保存每个文件的上传记录到文件系统中，用于断点续传
+    上传记录为json格式：
+    {
+        "size": file_size,
+        "offset": upload_offset,
+        "modify_time": file_modify_time,
+        "contexts": contexts
+    }
 
-  Attributes:
-      record_folder: 保存上传记录的目录
-  """
-  def __init__(self, record_folder=tempfile.gettempdir()):
-      self.record_folder = record_folder
+    Attributes:
+        record_folder: 保存上传记录的目录
+    """
+    def __init__(self, record_folder=tempfile.gettempdir()):
+        self.record_folder = record_folder
 
+    def get_upload_record(self, key):
+        upload_record_file_path = os.path.join(self.record_folder, key)
+        if not os.path.isfile(upload_record_file_path):
+            return None
+        with open(upload_record_file_path, 'r') as f:
+            json_data = json.load(f)
+        return json_data
 
-  def get_upload_record(self, key):
-      upload_record_file_path = os.path.join(self.record_folder, key)
-      if not os.path.isfile(upload_record_file_path):
-          return None
-      with open(upload_record_file_path, 'r') as f:
-          json_data = json.load(f)
-      return json_data
+    def set_upload_record(self, key, data):
+        upload_record_file_path = os.path.join(self.record_folder, key)
+        folder = os.path.dirname(upload_record_file_path)
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        with open(upload_record_file_path, 'w') as f:
+            json.dump(data, f)
 
-
-  def set_upload_record(self, key, data):
-      upload_record_file_path = os.path.join(self.record_folder, key)
-      folder = os.path.dirname(upload_record_file_path)
-      if not os.path.exists(folder):
-          os.makedirs(folder)
-      with open(upload_record_file_path, 'w') as f:
-          json.dump(data, f)
-
-
-  def delete_upload_record(self, key):
-      record_file_path = os.path.join(self.record_folder, key)
-      os.remove(record_file_path)
+    def delete_upload_record(self, key):
+        record_file_path = os.path.join(self.record_folder, key)
+        os.remove(record_file_path)

--- a/qiniu/services/storage/upload_progress_recorder.py
+++ b/qiniu/services/storage/upload_progress_recorder.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import tempfile
+
+class UploadProgressRecorder(object):
+  """持久化上传记录类
+
+  该类默认保存每个文件的上传记录到文件系统中，用于断点续传
+  上传记录为json格式：
+  {
+      "size": file_size,
+      "offset": upload_offset,
+      "modify_time": file_modify_time,
+      "contexts": contexts
+  }
+
+  Attributes:
+      record_folder: 保存上传记录的目录
+  """
+  def __init__(self, record_folder=tempfile.gettempdir()):
+      self.record_folder = record_folder
+
+
+  def get_upload_record(self, key):
+      upload_record_file_path = os.path.join(self.record_folder, key)
+      if not os.path.isfile(upload_record_file_path):
+          return None
+      with open(upload_record_file_path, 'r') as f:
+          json_data = json.load(f)
+      return json_data
+
+
+  def set_upload_record(self, key, data):
+      upload_record_file_path = os.path.join(self.record_folder, key)
+      folder = os.path.dirname(upload_record_file_path)
+      if not os.path.exists(folder):
+          os.makedirs(folder)
+      with open(upload_record_file_path, 'w') as f:
+          json.dump(data, f)
+
+
+  def delete_upload_record(self, key):
+      record_file_path = os.path.join(self.record_folder, key)
+      os.remove(record_file_path)

--- a/qiniu/services/storage/upload_progress_recorder.py
+++ b/qiniu/services/storage/upload_progress_recorder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import base64
 import json
 import os
 import tempfile
@@ -24,7 +25,9 @@ class UploadProgressRecorder(object):
         self.record_folder = record_folder
 
     def get_upload_record(self, key):
-        upload_record_file_path = os.path.join(self.record_folder, key)
+        record_file_name = base64.b64encode(key.encode('utf-8')).decode('utf-8')
+        upload_record_file_path = os.path.join(self.record_folder,
+                                               record_file_name)
         if not os.path.isfile(upload_record_file_path):
             return None
         with open(upload_record_file_path, 'r') as f:
@@ -32,13 +35,14 @@ class UploadProgressRecorder(object):
         return json_data
 
     def set_upload_record(self, key, data):
-        upload_record_file_path = os.path.join(self.record_folder, key)
-        folder = os.path.dirname(upload_record_file_path)
-        if not os.path.exists(folder):
-            os.makedirs(folder)
+        record_file_name = base64.b64encode(key.encode('utf-8')).decode('utf-8')
+        upload_record_file_path = os.path.join(self.record_folder,
+                                               record_file_name)
         with open(upload_record_file_path, 'w') as f:
             json.dump(data, f)
 
     def delete_upload_record(self, key):
-        record_file_path = os.path.join(self.record_folder, key)
+        record_file_name = base64.b64encode(key.encode('utf-8')).decode('utf-8')
+        record_file_path = os.path.join(self.record_folder,
+                                        record_file_name)
         os.remove(record_file_path)

--- a/qiniu/services/storage/uploader.py
+++ b/qiniu/services/storage/uploader.py
@@ -5,6 +5,7 @@ import os
 from qiniu import config
 from qiniu.utils import urlsafe_base64_encode, crc32, file_crc32, _file_iter
 from qiniu import http
+from upload_progress_recorder import UploadProgressRecorder
 
 
 def put_data(
@@ -28,7 +29,10 @@ def put_data(
     return _form_put(up_token, key, data, params, mime_type, crc, progress_handler)
 
 
-def put_file(up_token, key, file_path, params=None, mime_type='application/octet-stream', check_crc=False, progress_handler=None):
+def put_file(up_token, key, file_path, params=None,
+             mime_type='application/octet-stream', check_crc=False,
+             progress_handler=None, upload_progress_recorder=None):
+
     """上传文件到七牛
 
     Args:
@@ -48,7 +52,10 @@ def put_file(up_token, key, file_path, params=None, mime_type='application/octet
     size = os.stat(file_path).st_size
     with open(file_path, 'rb') as input_stream:
         if size > config._BLOCK_SIZE * 2:
-            ret, info = put_stream(up_token, key, input_stream, size, params, mime_type, progress_handler)
+            ret, info = put_stream(up_token, key, input_stream, size, params,
+                                   mime_type, progress_handler,
+                                   upload_progress_recorder=upload_progress_recorder,
+                                   modify_time=(int)(os.path.getmtime(file_path)))
         else:
             crc = file_crc32(file_path) if check_crc else None
             ret, info = _form_put(up_token, key, input_stream, params, mime_type, crc, progress_handler)
@@ -83,15 +90,18 @@ def _form_put(up_token, key, data, params, mime_type, crc, progress_handler=None
     return r, info
 
 
-def put_stream(up_token, key, input_stream, data_size, params=None, mime_type=None, progress_handler=None):
-    task = _Resume(up_token, key, input_stream, data_size, params, mime_type, progress_handler)
+def put_stream(up_token, key, input_stream, data_size, params=None,
+               mime_type=None, progress_handler=None,
+               upload_progress_recorder=None, modify_time=None):
+    task = _Resume(up_token, key, input_stream, data_size, params, mime_type,
+                   progress_handler, upload_progress_recorder, modify_time)
     return task.upload()
 
 
 class _Resume(object):
     """断点续上传类
 
-    该类主要实现了断点续上传中的分块上传，以及相应地创建块和创建文件过程，详细规格参考：
+    该类主要实现了分块上传，断点续上，以及相应地创建块和创建文件过程，详细规格参考：
     http://developer.qiniu.com/docs/v6/api/reference/up/mkblk.html
     http://developer.qiniu.com/docs/v6/api/reference/up/mkfile.html
 
@@ -103,9 +113,12 @@ class _Resume(object):
         params:           自定义变量，规格参考 http://developer.qiniu.com/docs/v6/api/overview/up/response/vars.html#xvar
         mime_type:        上传数据的mimeType
         progress_handler: 上传进度
+        upload_progress_recorder:  记录上传进度，用于断点续传
+        modify_time:      上传文件修改日期
     """
 
-    def __init__(self, up_token, key, input_stream, data_size, params, mime_type, progress_handler):
+    def __init__(self, up_token, key, input_stream, data_size, params, mime_type,
+                 progress_handler, upload_progress_recorder, modify_time):
         """初始化断点续上传"""
         self.up_token = up_token
         self.key = key
@@ -114,12 +127,37 @@ class _Resume(object):
         self.params = params
         self.mime_type = mime_type
         self.progress_handler = progress_handler
+        self.upload_progress_recorder = upload_progress_recorder or UploadProgressRecorder()
+        self.modify_time = modify_time
+
+    def record_upload_progress(self, offset):
+        record_data = {
+            'size': self.size,
+            'offset': offset,
+            'contexts': [block['ctx'] for block in self.blockStatus]
+        }
+        if self.modify_time:
+            record_data['modify_time'] = self.modify_time
+        self.upload_progress_recorder.set_upload_record(self.key, record_data)
+
+    def recovery_from_record(self):
+        record = self.upload_progress_recorder.get_upload_record(self.key)
+        if not record:
+            return 0
+
+        if not record['modify_time'] or record['size'] != self.size or \
+            record['modify_time'] != self.modify_time:
+            return 0
+
+        self.blockStatus =  [{'ctx': ctx} for ctx in record['contexts']]
+        return record['offset']
 
     def upload(self):
         """上传操作"""
         self.blockStatus = []
         host = config.get_default('default_up_host')
-        for block in _file_iter(self.input_stream, config._BLOCK_SIZE):
+        offset = self.recovery_from_record()
+        for block in _file_iter(self.input_stream, config._BLOCK_SIZE, offset):
             length = len(block)
             crc = crc32(block)
             ret, info = self.make_block(block, length, host)
@@ -133,6 +171,8 @@ class _Resume(object):
                     return ret, info
 
             self.blockStatus.append(ret)
+            offset += length
+            self.record_upload_progress(offset)
             if(callable(self.progress_handler)):
                 self.progress_handler(((len(self.blockStatus) - 1) * config._BLOCK_SIZE)+length, self.size)
         return self.make_file(host)

--- a/qiniu/services/storage/uploader.py
+++ b/qiniu/services/storage/uploader.py
@@ -5,7 +5,7 @@ import os
 from qiniu import config
 from qiniu.utils import urlsafe_base64_encode, crc32, file_crc32, _file_iter
 from qiniu import http
-from upload_progress_recorder import UploadProgressRecorder
+from .upload_progress_recorder import UploadProgressRecorder
 
 
 def put_data(
@@ -31,7 +31,8 @@ def put_data(
 
 def put_file(up_token, key, file_path, params=None,
              mime_type='application/octet-stream', check_crc=False,
-             progress_handler=None, upload_progress_recorder=None):
+             progress_handler=None, upload_progress_recorder=None,
+             cancel_upload_signal=None):
 
     """上传文件到七牛
 
@@ -146,10 +147,10 @@ class _Resume(object):
             return 0
 
         if not record['modify_time'] or record['size'] != self.size or \
-            record['modify_time'] != self.modify_time:
+                record['modify_time'] != self.modify_time:
             return 0
 
-        self.blockStatus =  [{'ctx': ctx} for ctx in record['contexts']]
+        self.blockStatus = [{'ctx': ctx} for ctx in record['contexts']]
         return record['offset']
 
     def upload(self):

--- a/qiniu/services/storage/uploader.py
+++ b/qiniu/services/storage/uploader.py
@@ -31,9 +31,7 @@ def put_data(
 
 def put_file(up_token, key, file_path, params=None,
              mime_type='application/octet-stream', check_crc=False,
-             progress_handler=None, upload_progress_recorder=None,
-             cancel_upload_signal=None):
-
+             progress_handler=None, upload_progress_recorder=None):
     """上传文件到七牛
 
     Args:
@@ -44,6 +42,7 @@ def put_file(up_token, key, file_path, params=None,
         mime_type:        上传数据的mimeType
         check_crc:        是否校验crc32
         progress_handler: 上传进度
+        upload_progress_recorder: 记录上传进度，用于断点续传
 
     Returns:
         一个dict变量，类似 {"hash": "<Hash string>", "key": "<Key string>"}

--- a/qiniu/utils.py
+++ b/qiniu/utils.py
@@ -74,7 +74,7 @@ def crc32(data):
     return binascii.crc32(b(data)) & 0xffffffff
 
 
-def _file_iter(input_stream, size):
+def _file_iter(input_stream, size, offset=0):
     """读取输入流:
 
     Args:
@@ -84,6 +84,7 @@ def _file_iter(input_stream, size):
     Raises:
         IOError: 文件流读取失败
     """
+    input_stream.seek(offset)
     d = input_stream.read(size)
     while d:
         yield d


### PR DESCRIPTION
增加了断点续传的功能。目前通过[libchromiumcontent-qiniu-mirror](https://github.com/hokein/libchromiumcontent-qiniu-mirror)的测试，断点续传1.8G大小的文件正常。

现在不能编写自动化测试用例，可以考虑添加一个类似[`cancelSignal`](http://developer.qiniu.com/docs/v6/sdk/objc-sdk.html)的函数实现。请review一下这个PR，谢谢。