### PR TITLE
Streaming hash and chunked upload

### DIFF
--- a/qiniu/__init__.py
+++ b/qiniu/__init__.py
@@ -16,7 +16,7 @@ from .auth import Auth
 from .config import set_default, Zone
 
 from .services.storage.bucket import BucketManager, build_batch_copy, build_batch_rename, build_batch_move, build_batch_stat, build_batch_delete
-from .services.storage.uploader import put_data, put_file, put_stream
+from .services.storage.uploader import put_data, put_file
 from .services.processing.pfop import PersistentFop
 from .services.processing.cmd import build_op, pipe_cmd, op_save
 

--- a/qiniu/services/storage/uploader.py
+++ b/qiniu/services/storage/uploader.py
@@ -3,7 +3,7 @@
 import os
 
 from qiniu import config
-from qiniu.utils import urlsafe_base64_encode, crc32, file_crc32, _file_iter
+from qiniu.utils import urlsafe_base64_encode, file_block_crc32, crc32, file_crc32, _file_iter
 from qiniu import http
 from .upload_progress_recorder import UploadProgressRecorder
 
@@ -50,14 +50,14 @@ def put_file(up_token, key, file_path, params=None,
     """
     ret = {}
     size = os.stat(file_path).st_size
-    with open(file_path, 'rb') as input_stream:
-        if size > config._BLOCK_SIZE * 2:
-            ret, info = put_stream(up_token, key, input_stream, size, params,
-                                   mime_type, progress_handler,
-                                   upload_progress_recorder=upload_progress_recorder,
-                                   modify_time=(int)(os.path.getmtime(file_path)))
-        else:
-            crc = file_crc32(file_path) if check_crc else None
+    if size > config._BLOCK_SIZE * 2:
+        ret, info = _Resume(up_token, key, file_path, size, params,
+                               mime_type, progress_handler,
+                               upload_progress_recorder=upload_progress_recorder,
+                               modify_time=(int)(os.path.getmtime(file_path))).upload()
+    else:
+        crc = file_crc32(file_path) if check_crc else None
+        with open(file_path,'rb') as input_stream:
             ret, info = _form_put(up_token, key, input_stream, params, mime_type, crc, progress_handler)
     return ret, info
 
@@ -90,14 +90,6 @@ def _form_put(up_token, key, data, params, mime_type, crc, progress_handler=None
     return r, info
 
 
-def put_stream(up_token, key, input_stream, data_size, params=None,
-               mime_type=None, progress_handler=None,
-               upload_progress_recorder=None, modify_time=None):
-    task = _Resume(up_token, key, input_stream, data_size, params, mime_type,
-                   progress_handler, upload_progress_recorder, modify_time)
-    return task.upload()
-
-
 class _Resume(object):
     """断点续上传类
 
@@ -108,7 +100,7 @@ class _Resume(object):
     Attributes:
         up_token:         上传凭证
         key:              上传文件名
-        input_stream:     上传二进制流
+        file_path:        本地文件路径名称
         data_size:        上传流大小
         params:           自定义变量，规格参考 http://developer.qiniu.com/docs/v6/api/overview/up/response/vars.html#xvar
         mime_type:        上传数据的mimeType
@@ -117,12 +109,12 @@ class _Resume(object):
         modify_time:      上传文件修改日期
     """
 
-    def __init__(self, up_token, key, input_stream, data_size, params, mime_type,
-                 progress_handler, upload_progress_recorder, modify_time):
+    def __init__(self, up_token, key, file_path, data_size, params=None, mime_type=None,
+                 progress_handler=None, upload_progress_recorder=None, modify_time=None):
         """初始化断点续上传"""
         self.up_token = up_token
         self.key = key
-        self.input_stream = input_stream
+        self.file_path = file_path
         self.size = data_size
         self.params = params
         self.mime_type = mime_type
@@ -157,16 +149,16 @@ class _Resume(object):
         self.blockStatus = []
         host = config.get_default('default_up_host')
         offset = self.recovery_from_record()
-        for block in _file_iter(self.input_stream, config._BLOCK_SIZE, offset):
-            length = len(block)
-            crc = crc32(block)
-            ret, info = self.make_block(block, length, host)
+        for block_generator in _file_iter(self.file_path, config._BLOCK_SIZE, offset):
+            length = block_generator.length
+            crc = file_block_crc32(block_generator)
+            ret, info = self.make_block(block_generator, length, host)
             if ret is None and not info.need_retry():
                 return ret, info
             if info.connect_failed():
                 host = config.get_default('default_up_host_backup')
             if info.need_retry() or crc != ret['crc32']:
-                ret, info = self.make_block(block, length, host)
+                ret, info = self.make_block(block_generator, length, host)
                 if ret is None or crc != ret['crc32']:
                     return ret, info
 
@@ -177,10 +169,10 @@ class _Resume(object):
                 self.progress_handler(((len(self.blockStatus) - 1) * config._BLOCK_SIZE)+length, self.size)
         return self.make_file(host)
 
-    def make_block(self, block, block_size, host):
+    def make_block(self, block_generator, block_size, host):
         """创建块"""
         url = self.block_url(host, block_size)
-        return self.post(url, block)
+        return self.post(url, block_generator)
 
     def block_url(self, host, size):
         return 'http://{0}/mkblk/{1}'.format(host, size)

--- a/qiniu/services/storage/uploader.py
+++ b/qiniu/services/storage/uploader.py
@@ -52,12 +52,12 @@ def put_file(up_token, key, file_path, params=None,
     size = os.stat(file_path).st_size
     if size > config._BLOCK_SIZE * 2:
         ret, info = _Resume(up_token, key, file_path, size, params,
-                               mime_type, progress_handler,
-                               upload_progress_recorder=upload_progress_recorder,
-                               modify_time=(int)(os.path.getmtime(file_path))).upload()
+                            mime_type, progress_handler,
+                            upload_progress_recorder=upload_progress_recorder,
+                            modify_time=(int)(os.path.getmtime(file_path))).upload()
     else:
         crc = file_crc32(file_path) if check_crc else None
-        with open(file_path,'rb') as input_stream:
+        with open(file_path, 'rb') as input_stream:
             ret, info = _form_put(up_token, key, input_stream, params, mime_type, crc, progress_handler)
     return ret, info
 

--- a/qiniu/utils.py
+++ b/qiniu/utils.py
@@ -110,7 +110,7 @@ class _file_block_generator(object):
             self.length = os.stat(filePath).st_size
 
     def __iter__(self):
-        self.f = open(self.filePath,'rb')
+        self.f = open(self.filePath, 'rb')
         self.f.seek(self.offset)
         self.done = False
         self.rest = self.length
@@ -121,7 +121,7 @@ class _file_block_generator(object):
         return self.next()
 
     def next(self):
-        #Choose 8192 because httplib has hard-coded read size of 8192
+        # Choose 8192 because httplib has hard-coded read size of 8192
         if self.done:
             raise StopIteration
         if self.rest <= 8192:
@@ -171,7 +171,7 @@ def _sha1(block_generator):
 
 def etag(filePath):
     """计算文件的etag:
-    
+
     etag规格参考 http://developer.qiniu.com/docs/v6/api/overview/appendix.html#qiniu-etag
 
     Args:
@@ -189,6 +189,7 @@ def etag(filePath):
         data = _sha1(sha1_str)
         prefix = b('\x96')
     return urlsafe_base64_encode(prefix + data)
+
 
 def entry(bucket, key):
     """计算七牛API中的数据格式:


### PR DESCRIPTION
之前的做法需要将整4MB的文件段读到内存里再进行crc计算etag计算和分片上传，占用内存大，速度慢，改为以数据流的方式进行计算和上传
