### PR TITLE
修复大于4M的文件hash计算错误的问题

### DIFF
--- a/qiniu/utils.py
+++ b/qiniu/utils.py
@@ -117,6 +117,8 @@ def etag_stream(input_stream):
         输入流的etag值
     """
     array = [_sha1(block) for block in _file_iter(input_stream, _BLOCK_SIZE)]
+    if len(array) == 0:
+        array = [_sha1(b'')]
     if len(array) == 1:
         data = array[0]
         prefix = b'\x16'

--- a/qiniu/utils.py
+++ b/qiniu/utils.py
@@ -119,11 +119,11 @@ def etag_stream(input_stream):
     array = [_sha1(block) for block in _file_iter(input_stream, _BLOCK_SIZE)]
     if len(array) == 1:
         data = array[0]
-        prefix = b('\x16')
+        prefix = b'\x16'
     else:
         sha1_str = b('').join(array)
         data = _sha1(sha1_str)
-        prefix = b('\x96')
+        prefix = b'\x96'
     return urlsafe_base64_encode(prefix + data)
 
 


### PR DESCRIPTION
一个大于4M的mp4文件，etag函数计算的结果是`wpZpyHb7UsXVac8zH5QGJqZC_PrZUw==`，事实上七牛服务器的结果是`lmnIdvtSxdVpzzMflAYmpkL8-tlT`


原因：python3下`b('\x96')`的结果是`\xc2\x96`