### PR TITLE
fix uploading chinese name issue.

### DIFF
--- a/qiniu/services/storage/upload_progress_recorder.py
+++ b/qiniu/services/storage/upload_progress_recorder.py
@@ -42,6 +42,8 @@ class UploadProgressRecorder(object):
         record_file_name = base64.b64encode(key.encode('utf-8')).decode('utf-8')
         upload_record_file_path = os.path.join(self.record_folder,
                                                record_file_name)
+
+        upload_record_file_path = upload_record_file_path.replace('/', '')
         with open(upload_record_file_path, 'w') as f:
             json.dump(data, f)
 


### PR DESCRIPTION
the result of base64.b64encode may contain '/', and when open the
file, it will prompt 'cant fine file or directory' exception

fix, remove '/' from base64.b64encode

Bug https://github.com/qiniu/python-sdk/issues/223
