### PR TITLE
Update http.py

### DIFF
--- a/qiniu/http.py
+++ b/qiniu/http.py
@@ -38,7 +38,7 @@ def _post(url, data, files, auth, headers=None):
     if _session is None:
         _init()
     try:
-        post_headers = _headers
+        post_headers = _headers.copy()
         if headers is not None:
             for k, v in headers.items():
                 post_headers.update({k: v})


### PR DESCRIPTION
http.py文件  41行post_headers引用_headers，导致上传刷新再上传，第二次上传之后_header中的content-type为json传给post_headers。