### PR TITLE
添加遍历域名的接口

### DIFF
--- a/qiniu/services/cdn/manager.py
+++ b/qiniu/services/cdn/manager.py
@@ -260,6 +260,27 @@ class DomainManager(object):
         url = '{0}/sslcert'.format(self.server)
         return self.__post(url, body)
 
+    def sslcert_iter(self):
+        marker = None
+        while 1:
+            r = self.sslcert_list(200, marker)
+            li = r['certs']
+            if li:
+                for i in li:
+                    yield i
+                marker = r['marker']
+            else:
+                break
+
+    def sslcert_delete(self, certid):
+        return self.__delete("sslcert/"+certid)
+
+    def sslcert_list(self, limit=10, marker=None):
+        p = dict(limit=limit)
+        if marker:
+            p['marker']=marker
+        return self.__get("sslcert", p)[0]
+
     def domain_iter(self):
         """
         遍历所有域名
@@ -280,12 +301,17 @@ class DomainManager(object):
         p = dict(limit=limit)
         if marker:
             p['marker']=marker
-        return self.__get("domain", p)[0]
+        url = 'domain'
+        return self.__get(url, p)[0]
 
 
     def __post(self, url, data=None):
         headers = {'Content-Type': 'application/json'}
         return http._post_with_auth_and_headers(url, data, self.auth, headers)
+    
+    def __delete(self, url, data=None):
+        headers = {'Content-Type': 'application/json'}
+        return http._delete_with_auth_and_headers(url, data, self.auth, headers)
 
     def __put(self, url, data=None):
         headers = {'Content-Type': 'application/json'}

--- a/qiniu/services/cdn/manager.py
+++ b/qiniu/services/cdn/manager.py
@@ -273,7 +273,8 @@ class DomainManager(object):
                 break
 
     def sslcert_delete(self, certid):
-        return self.__delete("sslcert/"+certid)
+        url = '{0}/sslcert/{1}'.format(self.server, certid)
+        return self.__delete(url)
 
     def sslcert_list(self, limit=10, marker=None):
         p = dict(limit=limit)

--- a/qiniu/services/cdn/manager.py
+++ b/qiniu/services/cdn/manager.py
@@ -260,6 +260,29 @@ class DomainManager(object):
         url = '{0}/sslcert'.format(self.server)
         return self.__post(url, body)
 
+    def domain_iter(self):
+        """
+        遍历所有域名
+        """
+        marker = None
+        while 1:
+            r = self.domain_list(200, marker)
+            li = r['domains']
+            if li:
+                for i in li:
+                    yield i
+                marker = r['marker']
+            else:
+                break
+
+
+    def domain_list(self, limit=10, marker=None):
+        p = dict(limit=limit)
+        if marker:
+            p['marker']=marker
+        return self.__get(self.server+"/domain", p)[0]
+
+
     def __post(self, url, data=None):
         headers = {'Content-Type': 'application/json'}
         return http._post_with_auth_and_headers(url, data, self.auth, headers)
@@ -267,6 +290,9 @@ class DomainManager(object):
     def __put(self, url, data=None):
         headers = {'Content-Type': 'application/json'}
         return http._put_with_auth_and_headers(url, data, self.auth, headers)
+
+    def __get(self, url, params=None):
+        return http._get(url, params, self.auth)
 
 
 def create_timestamp_anti_leech_url(host, file_name, query_string, encrypt_key, deadline):

--- a/qiniu/services/cdn/manager.py
+++ b/qiniu/services/cdn/manager.py
@@ -280,7 +280,7 @@ class DomainManager(object):
         p = dict(limit=limit)
         if marker:
             p['marker']=marker
-        return self.__get(self.server+"/domain", p)[0]
+        return self.__get("domain", p)[0]
 
 
     def __post(self, url, data=None):
@@ -292,7 +292,7 @@ class DomainManager(object):
         return http._put_with_auth_and_headers(url, data, self.auth, headers)
 
     def __get(self, url, params=None):
-        return http._get(url, params, self.auth)
+        return http._get(self.server+"/"+url, params, self.auth)
 
 
 def create_timestamp_anti_leech_url(host, file_name, query_string, encrypt_key, deadline):


### PR DESCRIPTION
测试脚本如下
```
#!/usr/bin/env python
from qiniu import DomainManager
import qiniu

access_key = ""
secret_key = ""

auth = qiniu.Auth(access_key=access_key, secret_key=secret_key)
domain_manager = DomainManager(auth)
for i in domain_manager.domain_iter():
    print(i['name'])
```