### PR TITLE
Update auth.py

### DIFF
--- a/qiniu/auth.py
+++ b/qiniu/auth.py
@@ -264,8 +264,10 @@ class QiniuMacAuth(object):
         data += "\n"
 
         if content_type and content_type != "application/octet-stream" and body:
-            # data += body.decode(encoding='UTF-8')
-            data += body
+            if isinstance(body,bytes):
+                data += body.decode(encoding='UTF-8')
+            else:
+                data += body
         return '{0}:{1}'.format(self.__access_key, self.__token(data))
 
     def qiniu_headers(self, headers):


### PR DESCRIPTION
修复auth.py中token_of_request函数关于body类型对python2及python3的兼容（python3 requests模块r.body是字节类型，报data += body类型错误）