### PR TITLE
删除 encoding = 'utf-8' 参数

### DIFF
--- a/qiniu/http.py
+++ b/qiniu/http.py
@@ -23,7 +23,7 @@ def __return_wrapper(resp):
     if resp.status_code != 200 or resp.headers.get('X-Reqid') is None:
         return None, ResponseInfo(resp)
     resp.encoding = 'utf-8'
-    ret = resp.json(encoding='utf-8') if resp.text != '' else {}
+    ret = resp.json() if resp.text != '' else {}
     if ret is None:  # json null
         ret = {}
     return ret, ResponseInfo(resp)


### PR DESCRIPTION
如果没有安装 simplejson，默认使用 json，在执行 fetch 时，__return_wrapper 中使用 encoding='utf-8'，会导致
TypeError: __init__() got an unexpected keyword argument 'encoding'