### PR TITLE
兼容Python3.9 json.loads()方法

### DIFF
--- a/qiniu/config.py
+++ b/qiniu/config.py
@@ -38,7 +38,7 @@ def set_default(
     if default_api_host:
         _config['default_api_host'] = default_api_host
     if default_uc_host:
-        _config['default_uc_host'] = default_api_host
+        _config['default_uc_host'] = default_uc_host
     if connection_retries:
         _config['connection_retries'] = connection_retries
     if connection_pool:

--- a/qiniu/http.py
+++ b/qiniu/http.py
@@ -23,7 +23,7 @@ def __return_wrapper(resp):
     if resp.status_code != 200 or resp.headers.get('X-Reqid') is None:
         return None, ResponseInfo(resp)
     resp.encoding = 'utf-8'
-    ret = resp.json(encoding='utf-8') if resp.text != '' else {}
+    ret = resp.json() if resp.text != '' else {}
     if ret is None:  # json null
         ret = {}
     return ret, ResponseInfo(resp)

--- a/test_qiniu.py
+++ b/test_qiniu.py
@@ -330,7 +330,7 @@ class UploaderTestCase(unittest.TestCase):
     def test_withoutRead_withoutSeek_retry(self):
         key = 'retry'
         data = 'hello retry!'
-        set_default(default_zone=Zone('http://a', 'http://upload.qiniu.com'))
+        set_default(default_zone=Zone('http://a', 'http://upload.qiniup.com'))
         token = self.q.upload_token(bucket_name)
         ret, info = put_data(token, key, data)
         print(info)
@@ -393,7 +393,7 @@ class ResumableUploaderTestCase(unittest.TestCase):
         token = self.q.upload_token(bucket_name, key)
         localfile = create_temp_file(4 * 1024 * 1024 + 1)
         progress_handler = lambda progress, total: progress
-        qiniu.set_default(default_zone=Zone('http://a', 'http://upload.qiniu.com'))
+        qiniu.set_default(default_zone=Zone('http://a', 'http://upload.qiniup.com'))
         ret, info = put_file(token, key, localfile, self.params, self.mime_type, progress_handler=progress_handler)
         print(info)
         assert ret['key'] == key
@@ -402,7 +402,7 @@ class ResumableUploaderTestCase(unittest.TestCase):
     def test_retry(self):
         localfile = __file__
         key = 'test_file_r_retry'
-        qiniu.set_default(default_zone=Zone('http://a', 'http://upload.qiniu.com'))
+        qiniu.set_default(default_zone=Zone('http://a', 'http://upload.qiniup.com'))
         token = self.q.upload_token(bucket_name, key)
         ret, info = put_file(token, key, localfile, self.params, self.mime_type)
         print(info)


### PR DESCRIPTION
1、由于python3.9删除了json.loads()的encoding参数：https://docs.python.org/3/whatsnew/3.9.html，修改https://github.com/qiniu/python-sdk/blob/develop/qiniu/http.py#L26 的json处理，用于兼容python3.9。
![image](https://user-images.githubusercontent.com/48310409/101877119-7a858200-3bc8-11eb-809e-7a0b03466b72.png)
2、修改 https://github.com/qiniu/python-sdk/blob/00c1a67f6ecb39bf890be48828fb81cd8264357f/qiniu/config.py#L41 错误参数，客户反馈issues：https://github.com/qiniu/python-sdk/issues/381
