### PR TITLE
替换为使用公共的_session，以便支持代理

### DIFF
--- a/qiniu/http.py
+++ b/qiniu/http.py
@@ -185,12 +185,14 @@ def _get_with_qiniu_mac(url, params, auth):
 
 
 def _get_with_qiniu_mac_and_headers(url, params, auth, headers):
+    if _session is None:
+        _init()
     try:
         post_headers = _headers.copy()
         if headers is not None:
             for k, v in headers.items():
                 post_headers.update({k: v})
-        r = requests.get(
+        r = _session.get(
             url,
             params=params,
             auth=qiniu.auth.QiniuMacRequestsAuth(auth) if auth is not None else None,
@@ -202,8 +204,10 @@ def _get_with_qiniu_mac_and_headers(url, params, auth, headers):
 
 
 def _delete_with_qiniu_mac(url, params, auth):
+    if _session is None:
+        _init()
     try:
-        r = requests.delete(
+        r = _session.delete(
             url,
             params=params,
             auth=qiniu.auth.QiniuMacRequestsAuth(auth) if auth is not None else None,
@@ -215,12 +219,14 @@ def _delete_with_qiniu_mac(url, params, auth):
 
 
 def _delete_with_qiniu_mac_and_headers(url, params, auth, headers):
+    if _session is None:
+        _init()
     try:
         post_headers = _headers.copy()
         if headers is not None:
             for k, v in headers.items():
                 post_headers.update({k: v})
-        r = requests.delete(
+        r = _session.delete(
             url,
             params=params,
             auth=qiniu.auth.QiniuMacRequestsAuth(auth) if auth is not None else None,

--- a/qiniu/region.py
+++ b/qiniu/region.py
@@ -5,6 +5,7 @@ import time
 import requests
 from qiniu import compat
 from qiniu import utils
+from qiniu import http
 
 UC_HOST = 'https://uc.qbox.me'  # 获取空间信息Host
 
@@ -201,7 +202,9 @@ class Region(object):
         f.close()
 
     def bucket_hosts(self, ak, bucket):
+        if http._session is None:
+            http._init()
         url = "{0}/v1/query?ak={1}&bucket={2}".format(UC_HOST, ak, bucket)
-        ret = requests.get(url)
+        ret = http._session.get(url)
         data = compat.json.dumps(ret.json(), separators=(',', ':'))
         return data


### PR DESCRIPTION
#428 
```
proxies = {
    'http': 'http://x.x.x.x:8080',
    'https': 'http://x.x.x.x:8080',
}
http._init()
http._session.proxies.update(proxies)
```
虽然不够优雅，但是能用