### PR TITLE
DP-5290 python-sdk/cdn: 查询域名带宽，支持type参数

### DIFF
--- a/examples/cdn_bandwidth.py
+++ b/examples/cdn_bandwidth.py
@@ -5,7 +5,7 @@
 查询指定域名指定时间段内的带宽
 """
 import qiniu
-from qiniu import CdnManager
+from qiniu import CdnManager, DataType
 
 
 # 账户ak，sk
@@ -28,6 +28,12 @@ urls = [
 
 ret, info = cdn_manager.get_bandwidth_data(
     urls, startDate, endDate, granularity)
+
+print(ret)
+print(info)
+
+ret, info = cdn_manager.get_bandwidth_data(
+    urls, startDate, endDate, granularity, data_type=DataType.BANDWIDTH)
 
 print(ret)
 print(info)

--- a/qiniu/__init__.py
+++ b/qiniu/__init__.py
@@ -21,7 +21,7 @@ from .services.storage.bucket import BucketManager, build_batch_copy, build_batc
     build_batch_stat, build_batch_delete, build_batch_restoreAr, build_batch_restore_ar
 from .services.storage.uploader import put_data, put_file, put_stream
 from .services.storage.upload_progress_recorder import UploadProgressRecorder
-from .services.cdn.manager import CdnManager, create_timestamp_anti_leech_url, DomainManager
+from .services.cdn.manager import CdnManager, DataType, create_timestamp_anti_leech_url, DomainManager
 from .services.processing.pfop import PersistentFop
 from .services.processing.cmd import build_op, pipe_cmd, op_save
 from .services.compute.app import AccountClient

--- a/qiniu/services/cdn/manager.py
+++ b/qiniu/services/cdn/manager.py
@@ -5,9 +5,17 @@ import json
 
 from qiniu.compat import is_py2
 from qiniu.compat import is_py3
+from enum import Enum
 
 import hashlib
 
+class DataType(Enum):
+    BANDWIDTH = 'bandwidth'
+    X302BANDWIDTH = '302bandwidth'
+    X302MBANDWIDTH = '302mbandwidth'
+    FLOW = 'flow'
+    X302FLOW = '302flow'
+    X302MFLOW = '302mflow'
 
 def urlencode(str):
     if is_py2:
@@ -60,7 +68,7 @@ class CdnManager(object):
         Returns:
            一个dict变量和一个ResponseInfo对象
            参考代码 examples/cdn_manager.py
-       """
+        """
         req = {}
         if urls is not None and len(urls) > 0:
             req.update({"urls": urls})
@@ -89,7 +97,7 @@ class CdnManager(object):
         url = '{0}/v2/tune/prefetch'.format(self.server)
         return self.__post(url, body)
 
-    def get_bandwidth_data(self, domains, start_date, end_date, granularity):
+    def get_bandwidth_data(self, domains, start_date, end_date, granularity, data_type=None):
         """
         查询带宽数据，文档 https://developer.qiniu.com/fusion/api/traffic-bandwidth
 
@@ -98,6 +106,7 @@ class CdnManager(object):
            start_date:  起始日期
            end_date:    结束日期
            granularity: 数据间隔
+           data_type:   计量数据类型, see class DataType.XXXBANDWIDTH
 
         Returns:
            一个dict变量和一个ResponseInfo对象
@@ -108,12 +117,14 @@ class CdnManager(object):
         req.update({"startDate": start_date})
         req.update({"endDate": end_date})
         req.update({"granularity": granularity})
+        if data_type is not None:
+            req.update({'type': data_type.value}) # should be one of 'bandwidth', '302bandwidth', '302mbandwidth'
 
         body = json.dumps(req)
         url = '{0}/v2/tune/bandwidth'.format(self.server)
         return self.__post(url, body)
 
-    def get_flux_data(self, domains, start_date, end_date, granularity):
+    def get_flux_data(self, domains, start_date, end_date, granularity, data_type=None):
         """
         查询流量数据，文档 https://developer.qiniu.com/fusion/api/traffic-bandwidth
 
@@ -122,6 +133,7 @@ class CdnManager(object):
            start_date:  起始日期
            end_date:    结束日期
            granularity: 数据间隔
+           data_type:   计量数据类型, see class DataType.XXXFLOW
 
         Returns:
            一个dict变量和一个ResponseInfo对象
@@ -132,6 +144,8 @@ class CdnManager(object):
         req.update({"startDate": start_date})
         req.update({"endDate": end_date})
         req.update({"granularity": granularity})
+        if data_type is not None:
+            req.update({'type': data_type.value}) # should be one of 'flow', '302flow', '302mflow'
 
         body = json.dumps(req)
         url = '{0}/v2/tune/flux'.format(self.server)


### PR DESCRIPTION
- cdn/manager: add DataType class(enum), add optional parameter 'data_type' to `CdnManager.get_bandwidth_data` & `CdnManager.get_flux_data`
- see https://jira.qiniu.io/browse/DP-5290