### PR TITLE
feat(sandbox): sync latest public API

### DIFF
--- a/examples/sandbox_runtime_configuration.py
+++ b/examples/sandbox_runtime_configuration.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import os
+
+from sandbox_common import cleanup_sandbox, create_sandbox, run_example
+
+
+def main():
+    sandbox = create_sandbox(timeout=300)
+    try:
+        listed = sandbox.client.list_sandboxes_v2(
+            template=[sandbox.template_id],
+        )
+        print('sandboxes using template:', listed)
+
+        print('current injections:', sandbox.get_injections())
+        sandbox.update_injections([{
+            'type': 'http',
+            'base_url': 'https://api.example.com/v1/*',
+            'headers': {'X-From-Sandbox': 'qiniu-python-sdk'},
+        }])
+        print('updated injections:', sandbox.get_injections())
+
+        github_token = (
+            os.getenv('QINIU_SANDBOX_GITHUB_TOKEN') or
+            os.getenv('GITHUB_TOKEN')
+        )
+        if github_token:
+            sandbox.update_github_token(github_token)
+            print('updated GitHub token')
+        else:
+            print('GitHub token update skipped: '
+                  'QINIU_SANDBOX_GITHUB_TOKEN/GITHUB_TOKEN is not set')
+    finally:
+        cleanup_sandbox(sandbox)
+
+
+if __name__ == '__main__':
+    run_example(main)

--- a/examples/sandbox_runtime_configuration.py
+++ b/examples/sandbox_runtime_configuration.py
@@ -22,16 +22,13 @@ def main():
         }])
         print('updated injections:', sandbox.get_injections())
 
-        github_token = (
-            os.getenv('QINIU_SANDBOX_GITHUB_TOKEN') or
-            os.getenv('GITHUB_TOKEN')
-        )
+        github_token = os.getenv('QINIU_SANDBOX_GITHUB_TOKEN')
         if github_token:
             sandbox.update_github_token(github_token)
             print('updated GitHub token')
         else:
             print('GitHub token update skipped: '
-                  'QINIU_SANDBOX_GITHUB_TOKEN/GITHUB_TOKEN is not set')
+                  'QINIU_SANDBOX_GITHUB_TOKEN is not set')
     finally:
         cleanup_sandbox(sandbox)
 

--- a/examples/sandbox_templates.py
+++ b/examples/sandbox_templates.py
@@ -31,6 +31,9 @@ def main():
             created.get('id')
         )
         print('template:', created)
+        details = client.get_template(template_id)
+        print('names:', details.get('names'))
+        print('owned by requesting team:', details.get('isOwner'))
     finally:
         if template_id:
             try:

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -148,8 +148,12 @@ def _normalize_list_options(opts):
         opts['metadata'] = metadata
     if isinstance(opts.get('metadata'), dict):
         opts['metadata'] = urlencode(opts.get('metadata'))
-    if query.get('state') is not None:
-        opts['state'] = query.get('state')
+    for key in ('state', 'template'):
+        if query.get(key) is not None:
+            opts[key] = query.get(key)
+        value = opts.get(key)
+        if value is not None and not isinstance(value, basestring):
+            opts[key] = ','.join(value)
     return opts
 
 
@@ -374,6 +378,49 @@ class SandboxClient(object):
         )
 
     updateSandbox = update_sandbox
+
+    def get_sandbox_injections(self, sandbox_id):
+        _require_sandbox_id(sandbox_id)
+        return self._request(
+            'GET',
+            '/sandboxes/{0}/injections'.format(encode_path(sandbox_id)),
+        )
+
+    getSandboxInjections = get_sandbox_injections
+
+    def update_sandbox_injections(self, sandbox_id, injections):
+        _require_sandbox_id(sandbox_id)
+        if injections is None:
+            raise SandboxError('injections is required')
+        return self._request(
+            'PUT',
+            '/sandboxes/{0}/injections'.format(encode_path(sandbox_id)),
+            body={
+                'injections': [
+                    _normalize_injection(item) for item in injections
+                ],
+            },
+            empty=True,
+        )
+
+    updateSandboxInjections = update_sandbox_injections
+
+    def update_sandbox_github_token(
+            self, sandbox_id, authorization_token=None, **opts):
+        _require_sandbox_id(sandbox_id)
+        if authorization_token is None:
+            authorization_token = (
+                opts.get('authorizationToken') or opts.get('token'))
+        if not authorization_token:
+            raise SandboxError('authorization_token is required')
+        return self._request(
+            'PUT',
+            '/sandboxes/{0}/github-token'.format(encode_path(sandbox_id)),
+            body={'authorization_token': authorization_token},
+            empty=True,
+        )
+
+    updateSandboxGithubToken = update_sandbox_github_token
 
     def get_sandbox_metrics(self, sandbox_id, **opts):
         _require_sandbox_id(sandbox_id)

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -5,7 +5,12 @@ import time
 import requests
 
 from qiniu.auth import QiniuMacAuth, QiniuMacRequestsAuth
-from qiniu.compat import basestring, str as text_type, urlencode
+from qiniu.compat import (
+    basestring,
+    bytes as bytes_type,
+    str as text_type,
+    urlencode,
+)
 
 from .constants import DEFAULT_TEMPLATE
 from .errors import SandboxError, TemplateBuildError
@@ -152,9 +157,16 @@ def _normalize_list_options(opts):
         if query.get(key) is not None:
             opts[key] = query.get(key)
         value = opts.get(key)
-        if value is not None and not isinstance(value, basestring):
+        if isinstance(value, bytes_type):
+            opts[key] = value.decode('utf-8')
+        elif value is not None and not isinstance(value, basestring):
             try:
-                opts[key] = ','.join(text_type(item) for item in value)
+                opts[key] = text_type(',').join(
+                    item.decode('utf-8')
+                    if isinstance(item, bytes_type)
+                    else text_type(item)
+                    for item in value
+                )
             except TypeError:
                 opts[key] = text_type(value)
     return opts
@@ -395,6 +407,8 @@ class SandboxClient(object):
         _require_sandbox_id(sandbox_id)
         if injections is None:
             raise SandboxError('injections is required')
+        if isinstance(injections, dict):
+            injections = [injections]
         return self._request(
             'PUT',
             '/sandboxes/{0}/injections'.format(encode_path(sandbox_id)),

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -159,16 +159,16 @@ def _normalize_list_options(opts):
         value = opts.get(key)
         if isinstance(value, bytes_type):
             opts[key] = value.decode('utf-8')
+        elif hasattr(value, '__iter__') and not isinstance(
+                value, (basestring, dict)):
+            opts[key] = text_type(',').join(
+                item.decode('utf-8')
+                if isinstance(item, bytes_type)
+                else text_type(item)
+                for item in value
+            )
         elif value is not None and not isinstance(value, basestring):
-            try:
-                opts[key] = text_type(',').join(
-                    item.decode('utf-8')
-                    if isinstance(item, bytes_type)
-                    else text_type(item)
-                    for item in value
-                )
-            except TypeError:
-                opts[key] = text_type(value)
+            opts[key] = text_type(value)
     return opts
 
 
@@ -407,7 +407,7 @@ class SandboxClient(object):
         _require_sandbox_id(sandbox_id)
         if injections is None:
             raise SandboxError('injections is required')
-        if isinstance(injections, dict):
+        if isinstance(injections, dict) or hasattr(injections, 'to_dict'):
             injections = [injections]
         return self._request(
             'PUT',

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -413,7 +413,7 @@ class SandboxClient(object):
         _require_sandbox_id(sandbox_id)
         if injections is None:
             raise SandboxError('injections is required')
-        if isinstance(injections, basestring):
+        if isinstance(injections, (basestring, bytes_type)):
             raise SandboxError(
                 'injections must be a list, dict, or rule object')
         if isinstance(injections, dict) or hasattr(injections, 'to_dict'):

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -149,7 +149,7 @@ def _normalize_list_options(opts):
     opts = dict(opts or {})
     query = opts.pop('query', None) or {}
     metadata = query.get('metadata')
-    if metadata is not None:
+    if metadata is not None and 'metadata' not in opts:
         opts['metadata'] = metadata
     if isinstance(opts.get('metadata'), dict):
         opts['metadata'] = urlencode(opts.get('metadata'))
@@ -160,7 +160,7 @@ def _normalize_list_options(opts):
                 value is not None):
             opts[key] = value
     for key in ('state', 'template'):
-        if query.get(key) is not None and opts.get(key) is None:
+        if query.get(key) is not None and key not in opts:
             opts[key] = query.get(key)
         value = opts.get(key)
         if isinstance(value, bytes_type):
@@ -418,6 +418,12 @@ class SandboxClient(object):
                 'injections must be a list, dict, or rule object')
         if isinstance(injections, dict) or hasattr(injections, 'to_dict'):
             injections = [injections]
+        else:
+            try:
+                iter(injections)
+            except TypeError:
+                raise SandboxError(
+                    'injections must be a list, dict, or rule object')
         return self._request(
             'PUT',
             '/sandboxes/{0}/injections'.format(encode_path(sandbox_id)),

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -153,7 +153,10 @@ def _normalize_list_options(opts):
             opts[key] = query.get(key)
         value = opts.get(key)
         if value is not None and not isinstance(value, basestring):
-            opts[key] = ','.join(value)
+            try:
+                opts[key] = ','.join(str(item) for item in value)
+            except TypeError:
+                opts[key] = str(value)
     return opts
 
 

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -153,6 +153,12 @@ def _normalize_list_options(opts):
         opts['metadata'] = metadata
     if isinstance(opts.get('metadata'), dict):
         opts['metadata'] = urlencode(opts.get('metadata'))
+    for key, value in query.items():
+        if (
+                key not in ('metadata', 'state', 'template') and
+                key not in opts and
+                value is not None):
+            opts[key] = value
     for key in ('state', 'template'):
         if query.get(key) is not None:
             opts[key] = query.get(key)

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -5,7 +5,7 @@ import time
 import requests
 
 from qiniu.auth import QiniuMacAuth, QiniuMacRequestsAuth
-from qiniu.compat import basestring, urlencode
+from qiniu.compat import basestring, str as text_type, urlencode
 
 from .constants import DEFAULT_TEMPLATE
 from .errors import SandboxError, TemplateBuildError
@@ -154,9 +154,9 @@ def _normalize_list_options(opts):
         value = opts.get(key)
         if value is not None and not isinstance(value, basestring):
             try:
-                opts[key] = ','.join(str(item) for item in value)
+                opts[key] = ','.join(text_type(item) for item in value)
             except TypeError:
-                opts[key] = str(value)
+                opts[key] = text_type(value)
     return opts
 
 

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -155,13 +155,11 @@ def _normalize_list_options(opts):
         opts['metadata'] = urlencode(opts.get('metadata'))
     for key, value in query.items():
         if (
-                key not in ('metadata', 'state', 'template') and
+                key != 'metadata' and
                 key not in opts and
                 value is not None):
             opts[key] = value
     for key in ('state', 'template'):
-        if query.get(key) is not None and key not in opts:
-            opts[key] = query.get(key)
         value = opts.get(key)
         if isinstance(value, bytes_type):
             opts[key] = value.decode('utf-8')

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -413,6 +413,9 @@ class SandboxClient(object):
         _require_sandbox_id(sandbox_id)
         if injections is None:
             raise SandboxError('injections is required')
+        if isinstance(injections, basestring):
+            raise SandboxError(
+                'injections must be a list, dict, or rule object')
         if isinstance(injections, dict) or hasattr(injections, 'to_dict'):
             injections = [injections]
         return self._request(

--- a/qiniu/services/sandbox/client.py
+++ b/qiniu/services/sandbox/client.py
@@ -160,7 +160,7 @@ def _normalize_list_options(opts):
                 value is not None):
             opts[key] = value
     for key in ('state', 'template'):
-        if query.get(key) is not None:
+        if query.get(key) is not None and opts.get(key) is None:
             opts[key] = query.get(key)
         value = opts.get(key)
         if isinstance(value, bytes_type):

--- a/qiniu/services/sandbox/sandbox.py
+++ b/qiniu/services/sandbox/sandbox.py
@@ -262,9 +262,9 @@ class Sandbox(object):
 
     updateInjections = update_injections
 
-    def update_github_token(self, authorization_token):
+    def update_github_token(self, authorization_token=None, **opts):
         return self.client.update_sandbox_github_token(
-            self.sandbox_id, authorization_token)
+            self.sandbox_id, authorization_token, **opts)
 
     updateGithubToken = update_github_token
 

--- a/qiniu/services/sandbox/sandbox.py
+++ b/qiniu/services/sandbox/sandbox.py
@@ -251,6 +251,23 @@ class Sandbox(object):
 
     updateNetwork = update_network
 
+    def get_injections(self):
+        return self.client.get_sandbox_injections(self.sandbox_id)
+
+    getInjections = get_injections
+
+    def update_injections(self, injections):
+        return self.client.update_sandbox_injections(
+            self.sandbox_id, injections)
+
+    updateInjections = update_injections
+
+    def update_github_token(self, authorization_token):
+        return self.client.update_sandbox_github_token(
+            self.sandbox_id, authorization_token)
+
+    updateGithubToken = update_github_token
+
     def get_info(self):
         return self.client.get_sandbox(self.sandbox_id)
 

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -957,6 +957,17 @@ def test_update_sandbox_injections_requires_rules_value():
     assert client.session.requests == []
 
 
+def test_update_sandbox_injections_rejects_string_value():
+    client = SandboxClient(api_key='api-key', session=RecordingSession())
+
+    with pytest.raises(SandboxError) as err:
+        client.update_sandbox_injections(
+            'sbx123', 'invalid-string-injection')
+
+    assert 'injections must be a list, dict, or rule object' in str(err.value)
+    assert client.session.requests == []
+
+
 def test_update_sandbox_github_token_uses_api_field_name():
     session = RecordingSession([DummyResponse(204)])
     client = SandboxClient(api_key='api-key', session=session)

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -786,6 +786,17 @@ def test_list_sandboxes_v2_serializes_array_filters_from_query_options():
     assert query['state'] == ['running,paused']
 
 
+def test_list_sandboxes_v2_serializes_non_string_filter_values():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(template=[123, 456], state=7)
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['template'] == ['123,456']
+    assert query['state'] == ['7']
+
+
 def test_template_responses_preserve_names_and_ownership_metadata():
     session = RecordingSession([DummyResponse(200, {
         'templateID': 'tmpl123',
@@ -973,6 +984,22 @@ def test_sandbox_runtime_configuration_camel_case_aliases_delegate():
     assert sandbox.getInjections()['sandboxID'] == 'sbx123'
     assert sandbox.updateInjections([]) == ('sbx123', [])
     assert sandbox.updateGithubToken('token') == ('sbx123', 'token')
+
+
+def test_sandbox_github_token_helper_forwards_keyword_aliases():
+    class RuntimeConfigClient(object):
+        def update_sandbox_github_token(
+                self, sandbox_id, authorization_token=None, **opts):
+            return sandbox_id, authorization_token, opts
+
+    sandbox = Sandbox(client=RuntimeConfigClient(), sandbox_id='sbx123')
+
+    assert sandbox.update_github_token(token='token') == (
+        'sbx123', None, {'token': 'token'},
+    )
+    assert sandbox.updateGithubToken(authorizationToken='camel-token') == (
+        'sbx123', None, {'authorizationToken': 'camel-token'},
+    )
 
 
 def test_wait_for_build_retries_transient_sandbox_errors(monkeypatch):

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -797,6 +797,20 @@ def test_list_sandboxes_v2_serializes_non_string_filter_values():
     assert query['state'] == ['7']
 
 
+def test_list_sandboxes_v2_preserves_bytes_and_unicode_filter_values():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(
+        template=[u'团队/模板'],
+        state=b'running',
+    )
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['template'] == [u'团队/模板']
+    assert query['state'] == ['running']
+
+
 def test_template_responses_preserve_names_and_ownership_metadata():
     session = RecordingSession([DummyResponse(200, {
         'templateID': 'tmpl123',

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -779,11 +779,25 @@ def test_list_sandboxes_v2_serializes_array_filters_from_query_options():
     client.list_sandboxes_v2(query={
         'template': ['python', 'team/node'],
         'state': ['running', 'paused'],
+        'limit': 10,
+        'nextToken': 'next-page',
     })
 
     query = parse_qs(urlparse(session.requests[0].url).query)
     assert query['template'] == ['python,team/node']
     assert query['state'] == ['running,paused']
+    assert query['limit'] == ['10']
+    assert query['nextToken'] == ['next-page']
+
+
+def test_list_sandboxes_v2_explicit_options_override_extra_query_values():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(limit=20, query={'limit': 10})
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['limit'] == ['20']
 
 
 def test_list_sandboxes_v2_serializes_non_string_filter_values():

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -811,6 +811,27 @@ def test_list_sandboxes_v2_explicit_options_override_extra_query_values():
     assert query['template'] == ['python']
 
 
+def test_list_sandboxes_v2_explicit_none_options_override_query_values():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(
+        metadata=None,
+        state=None,
+        template=None,
+        query={
+            'metadata': {'app': 'tests'},
+            'state': ['paused'],
+            'template': ['node'],
+        },
+    )
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert 'metadata' not in query
+    assert 'state' not in query
+    assert 'template' not in query
+
+
 def test_list_sandboxes_v2_serializes_non_string_filter_values():
     session = RecordingSession([DummyResponse(200, {'items': []})])
     client = SandboxClient(api_key='api-key', session=session)
@@ -963,6 +984,16 @@ def test_update_sandbox_injections_rejects_string_value():
     with pytest.raises(SandboxError) as err:
         client.update_sandbox_injections(
             'sbx123', 'invalid-string-injection')
+
+    assert 'injections must be a list, dict, or rule object' in str(err.value)
+    assert client.session.requests == []
+
+
+def test_update_sandbox_injections_rejects_non_iterable_scalar():
+    client = SandboxClient(api_key='api-key', session=RecordingSession())
+
+    with pytest.raises(SandboxError) as err:
+        client.update_sandbox_injections('sbx123', 123)
 
     assert 'injections must be a list, dict, or rule object' in str(err.value)
     assert client.session.requests == []

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -794,10 +794,21 @@ def test_list_sandboxes_v2_explicit_options_override_extra_query_values():
     session = RecordingSession([DummyResponse(200, {'items': []})])
     client = SandboxClient(api_key='api-key', session=session)
 
-    client.list_sandboxes_v2(limit=20, query={'limit': 10})
+    client.list_sandboxes_v2(
+        limit=20,
+        state=['running'],
+        template=['python'],
+        query={
+            'limit': 10,
+            'state': ['paused'],
+            'template': ['node'],
+        },
+    )
 
     query = parse_qs(urlparse(session.requests[0].url).query)
     assert query['limit'] == ['20']
+    assert query['state'] == ['running']
+    assert query['template'] == ['python']
 
 
 def test_list_sandboxes_v2_serializes_non_string_filter_values():

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -797,6 +797,16 @@ def test_list_sandboxes_v2_serializes_non_string_filter_values():
     assert query['state'] == ['7']
 
 
+def test_list_sandboxes_v2_does_not_join_mapping_keys():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(template={'template': 'python'})
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['template'] == ["{'template': 'python'}"]
+
+
 def test_list_sandboxes_v2_preserves_bytes_and_unicode_filter_values():
     session = RecordingSession([DummyResponse(200, {'items': []})])
     client = SandboxClient(api_key='api-key', session=session)
@@ -890,6 +900,25 @@ def test_update_sandbox_injections_wraps_single_rule():
     assert body_of(session.requests[0]) == {'injections': [{
         'type': 'http',
         'base_url': 'https://api.example.com/*',
+    }]}
+
+
+def test_update_sandbox_injections_wraps_single_rule_object():
+    class InjectionRule(object):
+        def to_dict(self):
+            return {
+                'type': 'openai',
+                'apiKey': 'secret',
+            }
+
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.update_sandbox_injections('sbx123', InjectionRule())
+
+    assert body_of(session.requests[0]) == {'injections': [{
+        'type': 'openai',
+        'api_key': 'secret',
     }]}
 
 

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -762,6 +762,219 @@ def test_list_sandboxes_v2_accepts_metadata_string():
     assert query['metadata'] == ['user=abc&app=prod']
 
 
+def test_list_sandboxes_v2_serializes_template_filters_as_comma_string():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(template=['python', 'team/node'])
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['template'] == ['python,team/node']
+
+
+def test_list_sandboxes_v2_serializes_array_filters_from_query_options():
+    session = RecordingSession([DummyResponse(200, {'items': []})])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.list_sandboxes_v2(query={
+        'template': ['python', 'team/node'],
+        'state': ['running', 'paused'],
+    })
+
+    query = parse_qs(urlparse(session.requests[0].url).query)
+    assert query['template'] == ['python,team/node']
+    assert query['state'] == ['running,paused']
+
+
+def test_template_responses_preserve_names_and_ownership_metadata():
+    session = RecordingSession([DummyResponse(200, {
+        'templateID': 'tmpl123',
+        'aliases': ['python'],
+        'names': ['qiniu/python'],
+        'isOwner': False,
+        'builds': [],
+    })])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    template = client.get_template('tmpl123')
+
+    assert template['aliases'] == ['python']
+    assert template['names'] == ['qiniu/python']
+    assert template['isOwner'] is False
+    assert template['builds'] == []
+
+
+def test_get_sandbox_injections_returns_current_rules():
+    session = RecordingSession([DummyResponse(200, {
+        'injections': [{'type': 'id', 'ruleID': 'rule123'}],
+    })])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    result = client.get_sandbox_injections('sandbox/id')
+
+    assert result == {
+        'injections': [{'type': 'id', 'ruleID': 'rule123'}],
+    }
+    request = session.requests[0]
+    assert request.method == 'GET'
+    assert request.url == (
+        DEFAULT_ENDPOINT + '/sandboxes/sandbox%2Fid/injections')
+
+
+def test_update_sandbox_injections_replaces_normalized_rules():
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    result = client.update_sandbox_injections('sbx123', [{
+        'type': 'openai',
+        'baseUrl': 'https://api.openai.com/v1/*',
+        'apiKey': 'secret',
+    }])
+
+    assert result is None
+    request = session.requests[0]
+    assert request.method == 'PUT'
+    assert request.url == DEFAULT_ENDPOINT + '/sandboxes/sbx123/injections'
+    assert body_of(request) == {'injections': [{
+        'type': 'openai',
+        'base_url': 'https://api.openai.com/v1/*',
+        'api_key': 'secret',
+    }]}
+
+
+def test_update_sandbox_injections_accepts_empty_replacement():
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    assert client.update_sandbox_injections('sbx123', []) is None
+    assert body_of(session.requests[0]) == {'injections': []}
+
+
+def test_update_sandbox_injections_requires_rules_value():
+    client = SandboxClient(api_key='api-key', session=RecordingSession())
+
+    with pytest.raises(SandboxError) as err:
+        client.update_sandbox_injections('sbx123', None)
+
+    assert 'injections is required' in str(err.value)
+    assert client.session.requests == []
+
+
+def test_update_sandbox_github_token_uses_api_field_name():
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    result = client.update_sandbox_github_token(
+        'sbx123', authorization_token='github-token')
+
+    assert result is None
+    request = session.requests[0]
+    assert request.method == 'PUT'
+    assert request.url == DEFAULT_ENDPOINT + '/sandboxes/sbx123/github-token'
+    assert body_of(request) == {'authorization_token': 'github-token'}
+
+
+def test_update_sandbox_github_token_accepts_camel_case_alias():
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.update_sandbox_github_token(
+        'sbx123', authorizationToken='github-token')
+
+    assert body_of(session.requests[0]) == {
+        'authorization_token': 'github-token',
+    }
+
+
+def test_update_sandbox_github_token_requires_token():
+    client = SandboxClient(api_key='api-key', session=RecordingSession())
+
+    with pytest.raises(SandboxError) as err:
+        client.update_sandbox_github_token('sbx123')
+
+    assert 'authorization_token is required' in str(err.value)
+    assert client.session.requests == []
+
+
+@pytest.mark.parametrize('method,args', [
+    ('get_sandbox_injections', ()),
+    ('update_sandbox_injections', ([],)),
+    ('update_sandbox_github_token', ('github-token',)),
+])
+def test_runtime_configuration_methods_require_sandbox_id(method, args):
+    client = SandboxClient(api_key='api-key', session=RecordingSession())
+
+    with pytest.raises(SandboxError) as err:
+        getattr(client, method)(None, *args)
+
+    assert 'sandbox_id is required' in str(err.value)
+    assert client.session.requests == []
+
+
+def test_runtime_configuration_camel_case_aliases():
+    session = RecordingSession([
+        DummyResponse(200, {'injections': []}),
+        DummyResponse(204),
+        DummyResponse(204),
+    ])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    assert client.getSandboxInjections('sbx123') == {'injections': []}
+    assert client.updateSandboxInjections('sbx123', []) is None
+    assert client.updateSandboxGithubToken('sbx123', 'github-token') is None
+
+    assert [request.method for request in session.requests] == [
+        'GET', 'PUT', 'PUT',
+    ]
+
+
+def test_sandbox_runtime_configuration_helpers_delegate_to_client():
+    class RuntimeConfigClient(object):
+        def __init__(self):
+            self.calls = []
+
+        def get_sandbox_injections(self, sandbox_id):
+            self.calls.append(('get', sandbox_id))
+            return {'injections': []}
+
+        def update_sandbox_injections(self, sandbox_id, injections):
+            self.calls.append(('injections', sandbox_id, injections))
+
+        def update_sandbox_github_token(self, sandbox_id, token):
+            self.calls.append(('github', sandbox_id, token))
+
+    client = RuntimeConfigClient()
+    sandbox = Sandbox(client=client, sandbox_id='sbx123')
+
+    assert sandbox.get_injections() == {'injections': []}
+    assert sandbox.update_injections([{'type': 'id', 'ruleID': 'rule123'}]) \
+        is None
+    assert sandbox.update_github_token('github-token') is None
+    assert client.calls == [
+        ('get', 'sbx123'),
+        ('injections', 'sbx123', [{'type': 'id', 'ruleID': 'rule123'}]),
+        ('github', 'sbx123', 'github-token'),
+    ]
+
+
+def test_sandbox_runtime_configuration_camel_case_aliases_delegate():
+    class RuntimeConfigClient(object):
+        def get_sandbox_injections(self, sandbox_id):
+            return {'sandboxID': sandbox_id, 'injections': []}
+
+        def update_sandbox_injections(self, sandbox_id, injections):
+            return sandbox_id, injections
+
+        def update_sandbox_github_token(self, sandbox_id, token):
+            return sandbox_id, token
+
+    sandbox = Sandbox(client=RuntimeConfigClient(), sandbox_id='sbx123')
+
+    assert sandbox.getInjections()['sandboxID'] == 'sbx123'
+    assert sandbox.updateInjections([]) == ('sbx123', [])
+    assert sandbox.updateGithubToken('token') == ('sbx123', 'token')
+
+
 def test_wait_for_build_retries_transient_sandbox_errors(monkeypatch):
     class BuildClient(SandboxClient):
         def __init__(self):

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -978,12 +978,15 @@ def test_update_sandbox_injections_requires_rules_value():
     assert client.session.requests == []
 
 
-def test_update_sandbox_injections_rejects_string_value():
+@pytest.mark.parametrize('injections', [
+    'invalid-string-injection',
+    b'invalid-bytes-injection',
+])
+def test_update_sandbox_injections_rejects_string_value(injections):
     client = SandboxClient(api_key='api-key', session=RecordingSession())
 
     with pytest.raises(SandboxError) as err:
-        client.update_sandbox_injections(
-            'sbx123', 'invalid-string-injection')
+        client.update_sandbox_injections('sbx123', injections)
 
     assert 'injections must be a list, dict, or rule object' in str(err.value)
     assert client.session.requests == []

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -802,12 +802,15 @@ def test_list_sandboxes_v2_preserves_bytes_and_unicode_filter_values():
     client = SandboxClient(api_key='api-key', session=session)
 
     client.list_sandboxes_v2(
-        template=[u'团队/模板'],
-        state=b'running',
+        template=[u'团队/模板', b'team/node'],
+        state=[b'running'],
     )
 
     query = parse_qs(urlparse(session.requests[0].url).query)
-    assert query['template'] == [u'团队/模板']
+    template_value = query['template'][0]
+    if not isinstance(template_value, type(u'')):
+        template_value = template_value.decode('utf-8')
+    assert template_value == u'团队/模板,team/node'
     assert query['state'] == ['running']
 
 
@@ -873,6 +876,21 @@ def test_update_sandbox_injections_accepts_empty_replacement():
 
     assert client.update_sandbox_injections('sbx123', []) is None
     assert body_of(session.requests[0]) == {'injections': []}
+
+
+def test_update_sandbox_injections_wraps_single_rule():
+    session = RecordingSession([DummyResponse(204)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    client.update_sandbox_injections('sbx123', {
+        'type': 'http',
+        'baseUrl': 'https://api.example.com/*',
+    })
+
+    assert body_of(session.requests[0]) == {'injections': [{
+        'type': 'http',
+        'base_url': 'https://api.example.com/*',
+    }]}
 
 
 def test_update_sandbox_injections_requires_rules_value():

--- a/tests/cases/test_services/test_sandbox/test_example_config.py
+++ b/tests/cases/test_services/test_sandbox/test_example_config.py
@@ -52,6 +52,7 @@ def test_examples_cover_primary_sandbox_surfaces():
         'sandbox_lifecycle.py',
         'sandbox_observability.py',
         'sandbox_resources.py',
+        'sandbox_runtime_configuration.py',
         'sandbox_runtime.py',
         'sandbox_template_lifecycle.py',
         'sandbox_templates.py',
@@ -121,6 +122,19 @@ def test_examples_cover_primary_sandbox_surfaces():
             'push_branch_with_credentials',
             'KodoResource',
             'read_only=True',
+        ],
+        'sandbox_runtime_configuration.py': [
+            'get_injections',
+            'update_injections',
+            'update_github_token',
+            "os.getenv('GITHUB_TOKEN')",
+            'list_sandboxes_v2(',
+            'template=[sandbox.template_id]',
+        ],
+        'sandbox_templates.py': [
+            'get_template',
+            "details.get('names')",
+            "details.get('isOwner')",
         ],
     }
 

--- a/tests/cases/test_services/test_sandbox/test_example_config.py
+++ b/tests/cases/test_services/test_sandbox/test_example_config.py
@@ -25,6 +25,8 @@ def test_examples_handle_runtime_branches_in_code():
     connect = read_project_file('examples', 'sandbox_connect.py')
     resources = read_project_file('examples', 'sandbox_resources.py')
     runtime = read_project_file('examples', 'sandbox_runtime.py')
+    runtime_configuration = read_project_file(
+        'examples', 'sandbox_runtime_configuration.py')
     integration = read_project_file(
         'tests',
         'cases',
@@ -37,6 +39,7 @@ def test_examples_handle_runtime_branches_in_code():
     assert 'QINIU_SANDBOX_KODO_READ_ONLY' not in resources
     assert 'QINIU_SANDBOX_RUN_INTEGRATION' not in runtime
     assert 'QINIU_SANDBOX_TEST_TIMEOUT' not in runtime
+    assert "os.getenv('GITHUB_TOKEN')" not in runtime_configuration
     assert 'QINIU_SANDBOX_RUN_INTEGRATION' not in integration
     assert 'QINIU_SANDBOX_TEST_TIMEOUT' not in integration
 
@@ -127,7 +130,7 @@ def test_examples_cover_primary_sandbox_surfaces():
             'get_injections',
             'update_injections',
             'update_github_token',
-            "os.getenv('GITHUB_TOKEN')",
+            "os.getenv('QINIU_SANDBOX_GITHUB_TOKEN')",
             'list_sandboxes_v2(',
             'template=[sandbox.template_id]',
         ],


### PR DESCRIPTION
## Summary

- sync the Sandbox SDK with qiniu/api-specs#21 and qiniu/api-specs#22
- serialize template and state list filters according to the OpenAPI contract
- add runtime injection and GitHub token operations to `SandboxClient` and `Sandbox`
- document template ownership metadata and runtime configuration through examples
- cover the new operations, validation, aliases, response fields, and examples

## Validation

- `python -m pytest -q tests/cases/test_services/test_sandbox` — 137 passed, 2 skipped
- `flake8 --show-source --max-line-length=160 ./qiniu`
- compiled all Sandbox modules and examples
- `git diff --check`
- live Sandbox integration tests — 4 passed, 2 skipped for unsupported envd stdin/PTY input
- live verification of template filtering, injection replacement, GitHub token updates, and Kodo mounts

## Notes

The existing remote Git example paths remain dependent on external repository permissions and network availability; they are unrelated to the API additions in this PR.
