### PR TITLE
chore: release v7.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 7.18.2
+* Sandbox 列表支持模板和状态数组过滤，并补充模板名称与归属信息
+* Sandbox 新增运行时注入配置和 GitHub Token 更新接口
+
 ## 7.18.1
 * Sandbox 注入规则支持 `if_headers` / `if_queries` 条件匹配字段，并兼容 `ifHeaders` / `ifQueries` 入参别名
 

--- a/qiniu/__init__.py
+++ b/qiniu/__init__.py
@@ -9,7 +9,7 @@ For detailed document, please see:
 
 # flake8: noqa
 
-__version__ = '7.18.1'
+__version__ = '7.18.2'
 
 from .auth import Auth, QiniuMacAuth
 


### PR DESCRIPTION
## Summary

- bump the Python SDK version to 7.18.2
- document Sandbox template/state array filters and template ownership metadata
- document runtime injection configuration and GitHub token update APIs

## Validation

- version contract: CHANGELOG.md, qiniu/__init__.py, and setup.py report 7.18.2
- fork PR CI public test selection: 212 passed
- flake8 --show-source --max-line-length=160 ./qiniu
- python -m compileall -q qiniu examples/sandbox_*.py
- git diff --check

## Release

After this PR merges, create tag v7.18.2 and publish GitHub Release v7.18.2.