### PR TITLE
test(sandbox): cover default template listing

### DIFF
--- a/examples/sandbox_default_templates.py
+++ b/examples/sandbox_default_templates.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+from sandbox_common import run_example, sandbox_client
+
+
+def main():
+    client = sandbox_client()
+    templates = client.list_default_templates()
+
+    print('default templates:', len(templates))
+    for template in templates:
+        print(
+            '  - {0} (names: {1}, build status: {2})'.format(
+                template.get('templateID'),
+                template.get('names') or [],
+                template.get('buildStatus'),
+            )
+        )
+
+
+if __name__ == '__main__':
+    run_example(main)

--- a/examples/sandbox_templates.py
+++ b/examples/sandbox_templates.py
@@ -18,6 +18,17 @@ def main():
         .set_env('PYTHONUNBUFFERED', '1')
     )
 
+    default_templates = client.list_default_templates()
+    print('default templates:', len(default_templates))
+    for default_template in default_templates:
+        print(
+            '  - {0} (names: {1}, build status: {2})'.format(
+                default_template.get('templateID'),
+                default_template.get('names') or [],
+                default_template.get('buildStatus'),
+            )
+        )
+
     try:
         created = client.create_template(
             name='qiniu-python-sdk-example-{0}'.format(

--- a/tests/cases/test_services/test_sandbox/test_client.py
+++ b/tests/cases/test_services/test_sandbox/test_client.py
@@ -544,6 +544,53 @@ def test_delete_template_requires_template_id():
     assert 'template_id is required' in str(err.value)
 
 
+def test_list_default_templates_uses_public_endpoint():
+    templates = [
+        {
+            'templateID': 'tmpl-default-1',
+            'names': ['qiniu/code-interpreter'],
+            'buildStatus': 'ready',
+        },
+        {
+            'templateID': 'tmpl-default-2',
+            'names': ['qiniu/python'],
+            'buildStatus': 'ready',
+        },
+    ]
+    session = RecordingSession([DummyResponse(200, templates)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    result = client.list_default_templates()
+
+    assert result == templates
+    request = session.requests[0]
+    assert request.method == 'GET'
+    assert request.url == DEFAULT_ENDPOINT + '/default-templates'
+
+
+def test_list_default_templates_raises_sandbox_error_on_api_error():
+    session = RecordingSession([
+        DummyResponse(401, {'message': 'unauthorized'}),
+    ])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    with pytest.raises(SandboxError) as err:
+        client.list_default_templates()
+
+    assert 'status 401: unauthorized' in str(err.value)
+    assert err.value.response.status_code == 401
+    assert err.value.data == {'message': 'unauthorized'}
+
+
+def test_list_default_templates_camel_case_alias():
+    templates = [{'templateID': 'tmpl-default'}]
+    session = RecordingSession([DummyResponse(200, templates)])
+    client = SandboxClient(api_key='api-key', session=session)
+
+    assert client.listDefaultTemplates() == templates
+    assert session.requests[0].url == DEFAULT_ENDPOINT + '/default-templates'
+
+
 def test_sandbox_envd_and_file_urls_are_signed_when_token_is_available():
     sandbox = Sandbox(info={
         'sandboxID': 'sbx123',

--- a/tests/cases/test_services/test_sandbox/test_example_config.py
+++ b/tests/cases/test_services/test_sandbox/test_example_config.py
@@ -49,6 +49,7 @@ def test_examples_cover_primary_sandbox_surfaces():
         'sandbox_commands.py',
         'sandbox_connect.py',
         'sandbox_create.py',
+        'sandbox_default_templates.py',
         'sandbox_filesystem.py',
         'sandbox_git.py',
         'sandbox_injection_rules.py',
@@ -71,6 +72,13 @@ def test_examples_cover_primary_sandbox_surfaces():
             'commands.close_stdin',
             'commands.kill',
             'commands.connect',
+        ],
+        'sandbox_default_templates.py': [
+            'run_example(main)',
+            'list_default_templates',
+            "template.get('templateID')",
+            "template.get('names')",
+            "template.get('buildStatus')",
         ],
         'sandbox_filesystem.py': [
             'files.make_dir',
@@ -135,6 +143,7 @@ def test_examples_cover_primary_sandbox_surfaces():
             'template=[sandbox.template_id]',
         ],
         'sandbox_templates.py': [
+            'list_default_templates',
             'get_template',
             "details.get('names')",
             "details.get('isOwner')",

--- a/tests/cases/test_services/test_sandbox/test_integration.py
+++ b/tests/cases/test_services/test_sandbox/test_integration.py
@@ -87,6 +87,16 @@ def remote_git_credentials():
     return repo_url, username, password
 
 
+def test_list_default_templates():
+    templates = integration_client().list_default_templates()
+
+    assert isinstance(templates, list)
+    assert templates
+    for template in templates:
+        assert isinstance(template, dict)
+        assert template.get('templateID')
+
+
 def test_create_run_filesystem_and_kill_sandbox():
     sandbox = None
     client = integration_client()


### PR DESCRIPTION
## Summary

- add success, API error, and camelCase alias coverage for `list_default_templates`
- add a live integration test for the default-template endpoint
- add a read-only default-template example and extend the existing template example

## Background

`SandboxClient.list_default_templates()` already exposes `GET /default-templates`, but the public behavior lacked direct unit coverage, live integration validation, and a focused read-only example. This aligns the Python SDK verification surface with qiniu/go-sdk#230.

## Validation

- `flake8 --show-source --max-line-length=160 ./qiniu`
- `flake8 --show-source --max-line-length=160` on the changed examples and tests
- Sandbox unit tests: 147 passed
- CI public test selection with the mock server: 215 passed
- root `.env` live integration test: passed
- root `.env` read-only example: returned 8 default templates
- `git diff --check`
